### PR TITLE
Teftel Cat Stickers (animated & contrast optimized version)

### DIFF
--- a/src/stickers.yml
+++ b/src/stickers.yml
@@ -23,6 +23,18 @@
 #
 # ---------------- ⬇︎ PLEASE ADD NEW ENTRIES BELOW THIS LINE ⬇︎ -----------------
 
+73654ad8848a71b1136ee7512c74426c:
+  key: 2d71d74f3b3b7939fbb9026e9e67c3418e7ffaa94cc7e33bcdb35490d1577f6b
+  source: >-
+    https://www.behance.net/gallery/85197371/Cat-Teftel-Animated-Stickers-For-Telegram
+  tags:
+    - cat
+    - kitty
+    - animal
+    - cute
+    - pet
+  animated: true
+
 73a662e5754ee419fb014060d2e8399a:
   key: 22f55198a0359a062638501ed8209b818493c98d95f146724b3f6d956fe23785
   source: 'https://twitter.com/BubbleBerryInk/status/1357044921534971907'


### PR DESCRIPTION
Add Teftel Cat Stickers from Telegram. There are already two versions on here but one is not animated and the other has weird edges that do not look good, especially on dark backgrounds. This one has a white border for better contrast. Also it uses the correct emoji mapping like the original.